### PR TITLE
Uses Foundation to convert between units

### DIFF
--- a/WunderLINQ.xcodeproj/project.pbxproj
+++ b/WunderLINQ.xcodeproj/project.pbxproj
@@ -19,10 +19,8 @@
 		7E068BD92102C7DE0076EAAD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BD82102C7DE0076EAAD /* Accelerate.framework */; };
 		7E068BE82102C8820076EAAD /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDA2102C8810076EAAD /* CoreGraphics.framework */; };
 		7E068BE92102C8820076EAAD /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDB2102C8810076EAAD /* libz.tbd */; };
-		7E068BEA2102C8820076EAAD /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDC2102C8810076EAAD /* OpenGLES.framework */; };
 		7E068BEB2102C8820076EAAD /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDD2102C8810076EAAD /* CoreLocation.framework */; };
 		7E068BEC2102C8820076EAAD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDE2102C8810076EAAD /* UIKit.framework */; };
-		7E068BED2102C8820076EAAD /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDF2102C8810076EAAD /* GLKit.framework */; };
 		7E068BEE2102C8820076EAAD /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BE02102C8810076EAAD /* CoreImage.framework */; };
 		7E068BEF2102C8820076EAAD /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BE12102C8810076EAAD /* ImageIO.framework */; };
 		7E068BF02102C8820076EAAD /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BE22102C8810076EAAD /* SystemConfiguration.framework */; };
@@ -241,11 +239,9 @@
 				7E96D79221E78B7B00C6AB5F /* Security.framework in Frameworks */,
 				7E068BE82102C8820076EAAD /* CoreGraphics.framework in Frameworks */,
 				7E068BE92102C8820076EAAD /* libz.tbd in Frameworks */,
-				7E068BEA2102C8820076EAAD /* OpenGLES.framework in Frameworks */,
 				7E068BEB2102C8820076EAAD /* CoreLocation.framework in Frameworks */,
 				7E9516C2238A367000ED25F2 /* SpotifyiOS.framework in Frameworks */,
 				7E068BEC2102C8820076EAAD /* UIKit.framework in Frameworks */,
-				7E068BED2102C8820076EAAD /* GLKit.framework in Frameworks */,
 				7E068BEE2102C8820076EAAD /* CoreImage.framework in Frameworks */,
 				7E068BEF2102C8820076EAAD /* ImageIO.framework in Frameworks */,
 				7E068BF02102C8820076EAAD /* SystemConfiguration.framework in Frameworks */,

--- a/WunderLINQ/AboutViewController.swift
+++ b/WunderLINQ/AboutViewController.swift
@@ -42,15 +42,15 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
     
     @IBAction func sendLogsBtnPressed(_ sender: Any) {
         if MFMailComposeViewController.canSendMail() {
-            var dateFormat = "yyyyMMdd-HH:mm"
             var dateFormatter: DateFormatter {
                 let formatter = DateFormatter()
-                formatter.dateFormat = dateFormat
+                formatter.dateFormat = "yyyyMMdd-HH:mm"
                 formatter.locale = Locale.current
                 formatter.timeZone = TimeZone.current
                 return formatter
             }
             let today = dateFormatter.string(from: Date())
+
             let mailComposer = MFMailComposeViewController()
             mailComposer.setSubject("WunderLINQ iOS Debug Logs \(today)")
             mailComposer.setMessageBody("App Version: \(getAppInfo())\nFirmware Version: \(wlqData.getfirmwareVersion())\niOS Version: \(getOSInfo())\nDevice: \(UIDevice.current.modelName)\n\(NSLocalizedString("sendlogs_body", comment: ""))", isHTML: false)
@@ -188,8 +188,8 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
         controller.dismiss(animated: true)
     }
     
-    func getOSInfo()->String {
-        let os = ProcessInfo().operatingSystemVersion
+    func getOSInfo() -> String {
+        let os = ProcessInfo.processInfo.operatingSystemVersion
         return String(os.majorVersion) + "." + String(os.minorVersion) + "." + String(os.patchVersion)
     }
     

--- a/WunderLINQ/AboutViewController.swift
+++ b/WunderLINQ/AboutViewController.swift
@@ -64,20 +64,19 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
                 let attachmentData = try Data(contentsOf: fileURL)
                 mailComposer.addAttachmentData(attachmentData, mimeType: "text/csv", fileName: "dbg")
             } catch let error {
-                NSLog("We have encountered error \(error.localizedDescription)")
+                print("We have encountered error \(error.localizedDescription)")
             }
             do {
                 let logAttachmentData = try Data(contentsOf: logURL)
                 mailComposer.addAttachmentData(logAttachmentData, mimeType: "text/log", fileName: "wunderlinq.log")
             } catch let error {
-                NSLog("We have encountered error \(error.localizedDescription)")
+                print("We have encountered error \(error.localizedDescription)")
             }
             mailComposer.mailComposeDelegate = self
-            self.present(mailComposer, animated: true
-                , completion: nil)
+            self.present(mailComposer, animated: true, completion: nil)
             
         } else {
-            NSLog("Email is not configured in settings app or we are not able to send an email")
+            print("Email is not configured in settings app or we are not able to send an email")
         }
     }
     
@@ -87,10 +86,8 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
     }
     
     @objc func logoTap() {
-        guard let url = URL(string: "http://www.wunderlinq.com") else {
-            return //be safe
-        }
-        
+        let url = URL(string: "http://www.wunderlinq.com")!
+
         if #available(iOS 10.0, *) {
             UIApplication.shared.open(url, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
         } else {
@@ -159,19 +156,19 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
         var shouldDelete = true
         switch result {
         case .cancelled:
-            NSLog("User cancelled")
+            print("User cancelled")
             shouldDelete = false
             break
         case .saved:
-            NSLog("Mail is saved by user")
+            print("Mail is saved by user")
             shouldDelete = true
             break
         case .sent:
-            NSLog("Mail is sent successfully")
+            print("Mail is sent successfully")
             shouldDelete = true
             break
         case .failed:
-            NSLog("Sending mail is failed")
+            print("Sending mail is failed")
             shouldDelete = false
             break
         default:
@@ -185,7 +182,7 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
             do {
                 try FileManager.default.removeItem(at: fileURL)
             } catch _ as NSError {
-                //NSLog("Error: \(error.domain)")
+                //print("Error: \(error.domain)")
             }
         }
         controller.dismiss(animated: true)
@@ -196,7 +193,7 @@ class AboutViewController: UIViewController, MFMailComposeViewControllerDelegate
         return String(os.majorVersion) + "." + String(os.minorVersion) + "." + String(os.patchVersion)
     }
     
-    func getAppInfo()->String {
+    func getAppInfo() -> String {
         let dictionary = Bundle.main.infoDictionary!
         let version = dictionary["CFBundleShortVersionString"] as! String
         let build = dictionary["CFBundleVersion"] as! String

--- a/WunderLINQ/AppDelegate.swift
+++ b/WunderLINQ/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 .forEach { $0.perform(setHardwareLayout, with: nil) }
             
             //Read and populate defaults
-            registerDefaultsFromSettingsBundle();
+            registerDefaultsFromSettingsBundle()
             // Override point for customization after application launch.
             // Keep screen unlocked
             application.isIdleTimerDisabled = true

--- a/WunderLINQ/FirstRunViewController.swift
+++ b/WunderLINQ/FirstRunViewController.swift
@@ -47,10 +47,10 @@ class FirstRunViewController: UIViewController {
                 if granted {
                     // Authorized
                     //Nothing to do
-                    NSLog("Allowed to access contacts")
+                    print("Allowed to access contacts")
                 } else {
                     // Not allowed
-                    NSLog("Not Allowed to access contacts")
+                    print("Not Allowed to access contacts")
                 }
             }
             step = step + 1
@@ -63,11 +63,11 @@ class FirstRunViewController: UIViewController {
                 if granted == true {
                     // Authorized
                     //Nothing to do
-                    NSLog("Allowed to access to Camera")
+                    print("Allowed to access to Camera")
                 } else {
                     // Not allowed
                     // Prompt with warning and button to settings
-                    NSLog("Not Allowed to access Camera")
+                    print("Not Allowed to access Camera")
                 }
             })
             step = step + 1
@@ -80,11 +80,11 @@ class FirstRunViewController: UIViewController {
                 if granted == true {
                     // Authorized
                     //Nothing to do
-                    NSLog("Allowed to access to Microphone")
+                    print("Allowed to access to Microphone")
                 } else {
                     // Not allowed
                     // Prompt with warning and button to settings
-                    NSLog("Not Allowed to access to Microphone")
+                    print("Not Allowed to access to Microphone")
                 }
             })
             step = step + 1
@@ -97,9 +97,9 @@ class FirstRunViewController: UIViewController {
                 if status == .authorized{
                     // Authorized
                     //Nothing to do
-                    NSLog("Allowed to access the Photo Library")
+                    print("Allowed to access the Photo Library")
                 } else {
-                    NSLog("Not Allowed to access the Photo Library")
+                    print("Not Allowed to access the Photo Library")
                 }
             })
             step = step + 1
@@ -112,9 +112,9 @@ class FirstRunViewController: UIViewController {
                 if status == .authorized{
                     // Authorized
                     //Nothing to do
-                    NSLog("Allowed to access the Media Library")
+                    print("Allowed to access the Media Library")
                 } else {
-                    NSLog("Not Allowed to access the Media Library")
+                    print("Not Allowed to access the Media Library")
                 }
             }
             step = step + 1
@@ -124,9 +124,9 @@ class FirstRunViewController: UIViewController {
             messageTextField.text = NSLocalizedString("notification_alert_body", comment: "")
 
             if CLLocationManager.authorizationStatus() == .authorizedAlways {
-                NSLog("Allowed Always Location Access")
+                print("Allowed Always Location Access")
             } else {
-                NSLog("Not Allowed Location Access")
+                print("Not Allowed Location Access")
                 locationManager.requestAlwaysAuthorization()
             }
             step = step + 1
@@ -137,19 +137,19 @@ class FirstRunViewController: UIViewController {
             
             UNUserNotificationCenter.current().getNotificationSettings { (settings) in
                 if (settings.authorizationStatus == .authorized){
-                    NSLog("Allowed to use Notifications")
+                    print("Allowed to use Notifications")
                 } else {
                     if #available(iOS 10.0, *) {
                         let center  = UNUserNotificationCenter.current()
 
                         center.requestAuthorization(options: [.sound, .alert, .badge]) { (granted, error) in
                             if error == nil{
-                                NSLog("Allowed to use Notifications")
+                                print("Allowed to use Notifications")
                             }
                         }
 
                     }
-                    NSLog("Not Allowed to use Notifications")
+                    print("Not Allowed to use Notifications")
                 }
             }
             step = step + 1

--- a/WunderLINQ/MainCollectionViewController.swift
+++ b/WunderLINQ/MainCollectionViewController.swift
@@ -930,7 +930,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
     
     @objc func pauseScan() {
         // Scanning uses up battery on phone, so pause the scan process for the designated interval.
-        NSLog("PAUSING SCAN...")
+        print("PAUSING SCAN...")
         disconnectButton.isEnabled = true
         self.centralManager?.stopScan()
         Timer.scheduledTimer(timeInterval: timerPauseInterval, target: self, selector: #selector(self.resumeScan), userInfo: nil, repeats: false)
@@ -941,7 +941,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         let lastPeripherals = centralManager.retrieveConnectedPeripherals(withServices: [CBUUID(string: Device.WunderLINQServiceUUID)])
         
         if lastPeripherals.count > 0{
-            NSLog("FOUND WunderLINQ")
+            print("FOUND WunderLINQ")
             let device = lastPeripherals.last!;
             wunderLINQ = device;
             bleData.setPeripheral(peripheral: device)
@@ -949,7 +949,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         } else {
             if keepScanning {
                 // Start scanning again...
-                NSLog("RESUMING SCAN!")
+                print("RESUMING SCAN!")
                 disconnectButton.isEnabled = false
                 centralManager.scanForPeripherals(withServices: [CBUUID(string: Device.WunderLINQAdvertisingUUID)], options: nil)
                 Timer.scheduledTimer(timeInterval: timerScanInterval, target: self, selector: #selector(self.pauseScan), userInfo: nil, repeats: false)
@@ -993,7 +993,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         case 15:
             cellDataPoint = UserDefaults.standard.integer(forKey: "grid_fifteen_preference")
         default:
-            NSLog("Unknown cell")
+            print("Unknown cell")
         }
         return cellDataPoint
     }
@@ -1018,7 +1018,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         case 3:
             pressureUnit = "psi"
         default:
-            NSLog("Unknown pressure unit setting")
+            print("Unknown pressure unit setting")
         }
         if UserDefaults.standard.integer(forKey: "temperature_unit_preference") == 1 {
             temperatureUnit = "F"
@@ -1136,7 +1136,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
             //RPM
             label = NSLocalizedString("leanangle_bike_header", comment: "")
         default:
-            NSLog("Unknown : \(cellDataPoint)")
+            print("Unknown : \(cellDataPoint)")
         }
         
         return label
@@ -1240,7 +1240,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
             //Lean Angle Bike
             icon = (UIImage(named: "Angle")?.withRenderingMode(.alwaysTemplate))!
         default:
-            NSLog("Unknown : \(cellDataPoint)")
+            print("Unknown : \(cellDataPoint)")
         }
         
         return icon
@@ -1812,7 +1812,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
                 value = "\(Int(round(motorcycleData.leanAngleBike!)))"
             }
         default:
-            NSLog("Unknown : \(dataPoint)")
+            print("Unknown : \(dataPoint)")
         }
         if let cell = self.collectionView.cellForItem(at: IndexPath(row: cellNumber - 1, section: 0) as IndexPath) as? MainCollectionViewCell{
             cell.setLabel(label: label)
@@ -1833,7 +1833,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
                 messageHexString += ","
             }
         }
-        //NSLog("Command Response Received: \(messageHexString)")
+        //print("Command Response Received: \(messageHexString)")
         
         switch (dataArray[0]){
         case 0x57:
@@ -3173,7 +3173,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         case .poweredOn:
             showAlert = false
             message = NSLocalizedString("bt_ready", comment: "")
-            NSLog(message)
+            print(message)
             resumeScan()
         default:
             message = NSLocalizedString("bt_unknown", comment: "")
@@ -3207,7 +3207,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         // Retrieve the peripheral name from the advertisement data using the "kCBAdvDataLocalName" key
         if let peripheralName = advertisementData[CBAdvertisementDataLocalNameKey] as? String {
             if peripheralName == deviceName {
-                NSLog("WunderLINQ FOUND! ADDING NOW!!!")
+                print("WunderLINQ FOUND! ADDING NOW!!!")
                 // to save power, stop scanning for other devices
                 keepScanning = false
                 disconnectButton.isEnabled = true
@@ -3229,10 +3229,10 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
      You typically implement this method to set the peripheral’s delegate and to discover its services.
      */
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        NSLog("SUCCESSFULLY CONNECTED TO WunderLINQ!")
+        print("SUCCESSFULLY CONNECTED TO WunderLINQ!")
         disconnectBtn.tintColor = UIColor.blue
         
-        NSLog("Peripheral info: \(peripheral)")
+        print("Peripheral info: \(peripheral)")
         peripheral.delegate = self
         
         // Now that we've successfully connected to the WunderLINQ, let's discover the services.
@@ -3251,7 +3251,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
      in which case you may attempt to connect to the peripheral again.
      */
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
-        NSLog("CONNECTION TO WunderLINQ FAILED!")
+        print("CONNECTION TO WunderLINQ FAILED!")
         disconnectBtn.tintColor = UIColor.red
     }
     
@@ -3266,12 +3266,12 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
      Note that when a peripheral is disconnected, all of its services, characteristics, and characteristic descriptors are invalidated.
      */
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-        NSLog("DISCONNECTED FROM WunderLINQ!")
+        print("DISCONNECTED FROM WunderLINQ!")
         disconnectBtn.tintColor = UIColor.red
         motorcycleData.clear()
         updateMessageDisplay()
         if error != nil {
-            NSLog("DISCONNECTION DETAILS: \(error!.localizedDescription)")
+            print("DISCONNECTION DETAILS: \(error!.localizedDescription)")
         }
         wunderLINQ = nil
         popoverMenuList = [NSLocalizedString("bike_info_label", comment: ""),NSLocalizedString("geodata_label", comment: ""),NSLocalizedString("appsettings_label", comment: ""), NSLocalizedString("about_label", comment: ""), NSLocalizedString("close_label", comment: "")]
@@ -3297,14 +3297,14 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
     // When the specified services are discovered, the peripheral calls the peripheral:didDiscoverServices: method of its delegate object.
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         if error != nil {
-            NSLog("ERROR DISCOVERING SERVICES: \(error?.localizedDescription ?? "Unknown Error")")
+            print("ERROR DISCOVERING SERVICES: \(error?.localizedDescription ?? "Unknown Error")")
             return
         }
         
         // Core Bluetooth creates an array of CBService objects —- one for each service that is discovered on the peripheral.
         if let services = peripheral.services {
             for service in services {
-                NSLog("DISCOVERED SERVICE: \(service)")
+                print("DISCOVERED SERVICE: \(service)")
                 // discover the characteristic.
                 if (service.uuid == CBUUID(string: Device.WunderLINQServiceUUID)) {
                     peripheral.discoverCharacteristics(nil, for: service)
@@ -3324,7 +3324,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
      */
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         if error != nil {
-            NSLog("ERROR DISCOVERING CHARACTERISTICS: \(error?.localizedDescription ?? "Unknown Error")")
+            print("ERROR DISCOVERING CHARACTERISTICS: \(error?.localizedDescription ?? "Unknown Error")")
             return
         }
         
@@ -3366,7 +3366,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
      */
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         if error != nil {
-            NSLog("ERROR ON UPDATING VALUE FOR CHARACTERISTIC: \(characteristic) - \(error?.localizedDescription ?? "Unknown Error")")
+            print("ERROR ON UPDATING VALUE FOR CHARACTERISTIC: \(characteristic) - \(error?.localizedDescription ?? "Unknown Error")")
             return
         }
         
@@ -3544,7 +3544,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
                 rowCount = 1
                 nextCellCount = 1
             default:
-                NSLog("Unknown Cell Count")
+                print("Unknown Cell Count")
             }
         } else {
             switch (cellCount){
@@ -3577,7 +3577,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
                 rowCount = 1
                 nextCellCount = 1
             default:
-                NSLog("Unknown Cell Count")
+                print("Unknown Cell Count")
             }
         }
         UserDefaults.standard.set(nextCellCount, forKey: "GRIDCOUNT")
@@ -3620,7 +3620,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
                 rowCount = 3
                 nextCellCount = 12
             default:
-                NSLog("Unknown Cell Count")
+                print("Unknown Cell Count")
             }
         } else {
             switch (cellCount){
@@ -3653,7 +3653,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
                 rowCount = 4
                 nextCellCount = 12
             default:
-                NSLog("Unknown Cell Count")
+                print("Unknown Cell Count")
             }
         }
         UserDefaults.standard.set(nextCellCount, forKey: "GRIDCOUNT")
@@ -3819,7 +3819,7 @@ class MainCollectionViewController: UIViewController, UICollectionViewDataSource
         case 14:
             UserDefaults.standard.set(selectedDataPoint, forKey: "grid_fifteen_preference")
         default:
-            NSLog("Unknown Cell")
+            print("Unknown Cell")
         }
         let _ = UserDefaults.standard.synchronize()
     }
@@ -3937,7 +3937,7 @@ extension MainCollectionViewController: UITableViewDelegate {
         case 5:
             exit(0)
         default:
-            NSLog("Unknown option")
+            print("Unknown option")
         }
         self.popover.dismiss()
     }

--- a/WunderLINQ/MotorcycleData.swift
+++ b/WunderLINQ/MotorcycleData.swift
@@ -57,7 +57,7 @@ class MotorcycleData {
     func setLocation(location: CLLocation?){
         self.location = location
     }
-    func getLocation() -> CLLocation{
+    func getLocation() -> CLLocation {
         return self.location!
     }
     

--- a/WunderLINQ/TasksCollectionViewController.swift
+++ b/WunderLINQ/TasksCollectionViewController.swift
@@ -769,7 +769,7 @@ class TasksCollectionViewController: UICollectionViewController, UICollectionVie
     }
     
     @objc func leftScreen() {
-        NSLog("Task: leftScreen()")
+        print("Task: leftScreen()")
         let secondViewController = self.storyboard!.instantiateViewController(withIdentifier: "MusicViewController") as! MusicViewController
         if let viewControllers = self.navigationController?.viewControllers
         {
@@ -786,7 +786,7 @@ class TasksCollectionViewController: UICollectionViewController, UICollectionVie
     }
     
     @objc func rightScreen() {
-        NSLog("Task: leftScreen()")
+        print("Task: leftScreen()")
         navigationController?.popToRootViewController(animated: true)
     }
     
@@ -800,7 +800,7 @@ class TasksCollectionViewController: UICollectionViewController, UICollectionVie
     
     @objc func handleGesture(gesture: UISwipeGestureRecognizer) -> Void {
         if gesture.direction == UISwipeGestureRecognizer.Direction.right {
-            NSLog("Task: swipe right")
+            print("Task: swipe right")
             let secondViewController = self.storyboard!.instantiateViewController(withIdentifier: "MusicViewController") as! MusicViewController
             if let viewControllers = self.navigationController?.viewControllers
             {
@@ -816,7 +816,7 @@ class TasksCollectionViewController: UICollectionViewController, UICollectionVie
             }
         }
         else if gesture.direction == UISwipeGestureRecognizer.Direction.left {
-            NSLog("Task: swipe left")
+            print("Task: swipe left")
             navigationController?.popToRootViewController(animated: true)
         }
     }

--- a/WunderLINQ/TripViewController.swift
+++ b/WunderLINQ/TripViewController.swift
@@ -523,7 +523,7 @@ extension TripViewController: UITableViewDelegate {
             //Delete
             delete()
         default:
-            NSLog("Unknown option")
+            print("Unknown option")
         }
         self.popover.dismiss()
     }

--- a/WunderLINQ/Utility.swift
+++ b/WunderLINQ/Utility.swift
@@ -19,60 +19,68 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import Foundation
 
 class Utility {
+
+    private static func convert<T: Dimension>(value: Double, from: T, to: T) -> Double {
+        let measurement = Measurement(value: value, unit: from)
+        return measurement.converted(to: to).value
+    }
+
     // MARK: - Utility Methods
     // Unit Conversion Functions
     // bar to psi
-    class func barToPsi(_ bar:Double) -> Double {
-        let psi = bar * 14.5037738
-        return psi
+    static func barToPsi(_ bar:Double) -> Double {
+        return convert(value: bar, from: UnitPressure.bars,
+                       to: UnitPressure.poundsForcePerSquareInch)
     }
+
     // bar to kpa
-    class func barTokPa(_ bar:Double) -> Double {
-        let kpa = bar * 100.0
-        return kpa
+    static func barTokPa(_ bar: Double) -> Double {
+        convert(value: bar, from: UnitPressure.bars,
+                       to: UnitPressure.kilopascals)
     }
     // bar to kg-f
-    class func barTokgf(_ bar:Double) -> Double {
+    static func barTokgf(_ bar: Double) -> Double {
         let kgf = bar * 1.0197162129779
         return kgf
     }
     // kilometers to miles
-    class func kmToMiles(_ kilometers:Double) -> Double {
-        let miles = kilometers * 0.62137
-        return miles
+    class func kmToMiles(_ kilometers: Double) -> Double {
+        convert(value: kilometers, from: UnitLength.kilometers,
+                to: UnitLength.miles)
     }
+
     // Celsius to Fahrenheit
-    class func celciusToFahrenheit(_ celcius:Double) -> Double {
-        let fahrenheit = (celcius * 1.8) + Double(32)
-        return fahrenheit
+    static func celciusToFahrenheit(_ celcius:Double) -> Double {
+        convert(value: celcius, from: UnitTemperature.celsius, to: UnitTemperature.fahrenheit)
     }
     // L/100 to mpg
     class func l100ToMpg(_ l100:Double) -> Double {
-        let mpg = 235.215 / l100
-        return mpg
+        convert(value: l100, from: UnitFuelEfficiency.litersPer100Kilometers,
+                to: UnitFuelEfficiency.milesPerGallon)
     }
+
     // L/100 to mpg Imperial
     class func l100ToMpgi(_ l100:Double) -> Double {
-        let mpgi = (235.215 / l100) * 1.20095
-        return mpgi
+        convert(value: l100, from: UnitFuelEfficiency.litersPer100Kilometers,
+                to: UnitFuelEfficiency.milesPerImperialGallon)
     }
     // L/100 to km/L
-    class func l100Tokml(_ l100:Double) -> Double {
+    class func l100Tokml(_ l100: Double) -> Double {
         let kml = l100 / 100.0
         return kml
     }
     // meters to feet
     class func mtoFeet(_ meters:Double) -> Double {
-        let meters = meters / 0.3048
-        return meters
+        convert(value: meters, from: UnitLength.meters, to: UnitLength.feet)
     }
+
     //radians to degrees
     class func degrees(radians:Double) -> Double {
-        return 180 / Double.pi * radians
+        convert(value: radians, from: UnitAngle.radians, to: UnitAngle.degrees)
     }
     
     // Calculate time duration
-    class func calculateDuration(start:String, end:String) -> String{
+    class func calculateDuration(start:String, end:String) -> String {
         var dateFormat = "yyyyMMdd-HH:mm:ss"
         var dateFormatter: DateFormatter {
             let formatter = DateFormatter()

--- a/WunderLINQ/WaypointViewController.swift
+++ b/WunderLINQ/WaypointViewController.swift
@@ -402,7 +402,7 @@ extension WaypointViewController: UITableViewDelegate {
             //Delete
             delete()
         default:
-            NSLog("Unknown option")
+            print("Unknown option")
         }
         self.popover.dismiss()
     }


### PR DESCRIPTION
Hi!
I recently started wondering "how could I connect my BMW to my phone?" and started browsing the internet on how to reverse engineer it.

Then I came across to this. 😄 


I've made a few changes I thought they would be welcome:
- It's using Foundation `Unit`s to convert between measurements
- It's now using "print" instead of NSLog to print on console
- Removed a few frameworks that I haven't seen around the code

I'm currently on Xcode 12, so that is something to consider when pulling code. I have more changes on my side, but I'd like to keep PRs small and more readable.

I have other few ideas as well, like decreasing the number of Singletons that are shared throughout the app, add unit tests, decouple that big `Main.storyboard` into smaller pieces, etc.

Let me know what you think, I'd be happy to help. :)