### PR TITLE
Simplifies navigation helper and adds MapOut integration

### DIFF
--- a/WunderLINQ.xcodeproj/project.pbxproj
+++ b/WunderLINQ.xcodeproj/project.pbxproj
@@ -19,10 +19,8 @@
 		7E068BD92102C7DE0076EAAD /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BD82102C7DE0076EAAD /* Accelerate.framework */; };
 		7E068BE82102C8820076EAAD /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDA2102C8810076EAAD /* CoreGraphics.framework */; };
 		7E068BE92102C8820076EAAD /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDB2102C8810076EAAD /* libz.tbd */; };
-		7E068BEA2102C8820076EAAD /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDC2102C8810076EAAD /* OpenGLES.framework */; };
 		7E068BEB2102C8820076EAAD /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDD2102C8810076EAAD /* CoreLocation.framework */; };
 		7E068BEC2102C8820076EAAD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDE2102C8810076EAAD /* UIKit.framework */; };
-		7E068BED2102C8820076EAAD /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BDF2102C8810076EAAD /* GLKit.framework */; };
 		7E068BEE2102C8820076EAAD /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BE02102C8810076EAAD /* CoreImage.framework */; };
 		7E068BEF2102C8820076EAAD /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BE12102C8810076EAAD /* ImageIO.framework */; };
 		7E068BF02102C8820076EAAD /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E068BE22102C8810076EAAD /* SystemConfiguration.framework */; };
@@ -241,11 +239,9 @@
 				7E96D79221E78B7B00C6AB5F /* Security.framework in Frameworks */,
 				7E068BE82102C8820076EAAD /* CoreGraphics.framework in Frameworks */,
 				7E068BE92102C8820076EAAD /* libz.tbd in Frameworks */,
-				7E068BEA2102C8820076EAAD /* OpenGLES.framework in Frameworks */,
 				7E068BEB2102C8820076EAAD /* CoreLocation.framework in Frameworks */,
 				7E9516C2238A367000ED25F2 /* SpotifyiOS.framework in Frameworks */,
 				7E068BEC2102C8820076EAAD /* UIKit.framework in Frameworks */,
-				7E068BED2102C8820076EAAD /* GLKit.framework in Frameworks */,
 				7E068BEE2102C8820076EAAD /* CoreImage.framework in Frameworks */,
 				7E068BEF2102C8820076EAAD /* ImageIO.framework in Frameworks */,
 				7E068BF02102C8820076EAAD /* SystemConfiguration.framework in Frameworks */,

--- a/WunderLINQ/AppDelegate.swift
+++ b/WunderLINQ/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 .forEach { $0.perform(setHardwareLayout, with: nil) }
             
             //Read and populate defaults
-            registerDefaultsFromSettingsBundle();
+            registerDefaultsFromSettingsBundle()
             // Override point for customization after application launch.
             // Keep screen unlocked
             application.isIdleTimerDisabled = true

--- a/WunderLINQ/File.swift
+++ b/WunderLINQ/File.swift
@@ -1,0 +1,9 @@
+//
+//  File.swift
+//  WunderLINQTests
+//
+//  Created by Matteo Comisso on 09/10/2020.
+//  Copyright © 2020 Black Box Embedded, LLC. All rights reserved.
+//
+
+import Foundation

--- a/WunderLINQ/InAppSettings.bundle/Integrations.plist
+++ b/WunderLINQ/InAppSettings.bundle/Integrations.plist
@@ -23,8 +23,9 @@
 				<integer>5</integer>
 				<integer>6</integer>
 				<integer>7</integer>
-                <integer>8</integer>
-                <integer>9</integer>
+				<integer>8</integer>
+				<integer>9</integer>
+				<string>10</string>
 			</array>
 			<key>Titles</key>
 			<array>
@@ -36,8 +37,9 @@
 				<string>nav_app_mapsme</string>
 				<string>nav_app_osmand</string>
 				<string>nav_app_here</string>
-                <string>nav_app_tomtomgo</string>
-                <string>nav_app_inroute</string>
+				<string>nav_app_tomtomgo</string>
+				<string>nav_app_inroute</string>
+				<string>nav_app_mapout</string>
 			</array>
 		</dict>
 		<dict>

--- a/WunderLINQ/InAppSettings.bundle/en.lproj/Integrations.strings
+++ b/WunderLINQ/InAppSettings.bundle/en.lproj/Integrations.strings
@@ -9,6 +9,7 @@
 "nav_app_here" = "HERE WeGo";
 "nav_app_tomtomgo" = "TomTom GO";
 "nav_app_inroute" = "inRoute";
+"nav_app_mapout" = "MapOut";
 "pref_actioncam_title" = "Action Camera";
 "actioncam_none" = "None";
 "actioncam_hero3" = "Hero3";

--- a/WunderLINQ/NavAppHelper.swift
+++ b/WunderLINQ/NavAppHelper.swift
@@ -20,144 +20,129 @@ import Foundation
 import MapKit
 import UIKit
 
-class NavAppHelper {
-    
-    class func open() {
-        let navApp = UserDefaults.standard.integer(forKey: "nav_app_preference")
-        switch (navApp){
-        case 0:
-            //Apple Maps
-            let map = MKMapItem()
-            map.openInMaps(launchOptions: nil)
-        case 1:
-            //Google Maps
-            //https://developers.google.com/maps/documentation/urls/ios-urlscheme
-            if let googleMapsURL = URL(string: "comgooglemaps-x-callback://?x-success=wunderlinq://&x-source=WunderLINQ") {
-                if (UIApplication.shared.canOpenURL(googleMapsURL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(googleMapsURL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(googleMapsURL as URL)
-                    }
-                }
-            }
-        case 2:
-            //Scenic
-            //https://github.com/guidove/Scenic-Integration/blob/master/README.md
-            let scenic = ScenicAPI()
-            scenic.sendToScenicForNavigation(coordinate: CLLocationCoordinate2D(latitude: 0,longitude: 0), name: "WunderLINQ")
-        case 3:
-            //Sygic
-            //https://www.sygic.com/developers/professional-navigation-sdk/ios/custom-url
-            let urlString = "com.sygic.aura://"
-            
-            if let sygicURL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
-                if (UIApplication.shared.canOpenURL(sygicURL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(sygicURL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(sygicURL as URL)
-                    }
-                }
-            }
-        case 4:
-            //Waze
-            if let wazeURL = URL(string: "waze://") {
-                if (UIApplication.shared.canOpenURL(wazeURL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(wazeURL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(wazeURL as URL)
-                    }
-                }
-            }
-        case 5:
-            //Maps.me
-            //https://github.com/mapsme/api-ios
-            if let mapsMeURL = URL(string: "mapsme://?backurl=wunderlinq://") {
-                if (UIApplication.shared.canOpenURL(mapsMeURL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(mapsMeURL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(mapsMeURL as URL)
-                    }
-                }
-            }
-        case 6:
-            //OsmAnd
-            // osmandmaps://?lat=45.6313&lon=34.9955&z=8&title=New+York
-            let urlString = "osmandmaps://"
-            if let osmAndURL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
-                if (UIApplication.shared.canOpenURL(osmAndURL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(osmAndURL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(osmAndURL as URL)
-                    }
-                }
-            }
-        case 7:
-            // Here We Go
-            // https://developer.here.com/documentation/mobility-on-demand-toolkit/dev_guide/topics/navigation.html
-            // here-route://mylocation/37.870090,-122.268150,Downtown%20Berkeley?ref=WunderLINQ&m=d
-            let urlString = "here-route://"
-            if let uRL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
-                if (UIApplication.shared.canOpenURL(uRL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(uRL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(uRL as URL)
-                    }
-                }
-            }
-        case 8:
-            // TomTom GO
-            // https://discussions.tomtom.com/en/discussion/1118783/url-schemes-for-go-navigation-ios/
-            // tomtomgo://x-callback-url/navigate?destination=52.371183,4.892504
-            let urlString = "tomtomgo://"
-            if let uRL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
-                if (UIApplication.shared.canOpenURL(uRL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(uRL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(uRL as URL)
-                    }
-                }
-            }
-        case 9:
-            //inRoute
-            //http://carobapps.com/products/inroute/url-scheme/
-            let urlString = "inroute://"
-            if let uRL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
-                if (UIApplication.shared.canOpenURL(uRL)) {
-                    if #available(iOS 10, *) {
-                        UIApplication.shared.open(uRL, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(uRL as URL)
-                    }
-                }
-            }
-        default:
-            //Apple Maps
-            let map = MKMapItem()
-            map.openInMaps(launchOptions: nil)
+/// All descriptions are accessible with option + click
+enum NavigationAppPreference: Int, CaseIterable {
+    /// Universal app link accessible with `maps://`
+    case appleMaps = 0
+
+    /// Universal app link accessible with `googlemaps://`, or x-callback `comgooglemaps-x-callback://`
+    case googleMaps
+
+    /// Integration guide: https://github.com/guidove/Scenic-Integration/blob/master/README.md
+    /// https://scenicapp.space/api/openScenic.php is a deeplink with app-site-association
+    case scenic
+
+    /// https://www.sygic.com/developers/professional-navigation-sdk/ios/custom-url
+    case sygic
+
+    /// Universal app link accessible with `waze://`
+    case waze
+
+    /// https://github.com/mapsme/api-ios
+    case mapsMe
+
+    /// Universal app link accessible with `osmandmaps://?lat=45.6313&lon=34.9955&z=8&title=New+York`
+    case osmAnd
+
+    /// https://developer.here.com/documentation/mobility-on-demand-toolkit/dev_guide/topics/navigation.html
+    /// Universal app link accessible with `here-route://mylocation/37.870090,-122.268150,Downtown%20Berkeley?ref=WunderLINQ&m=d`
+    case hereWeGo
+
+    /// https://discussions.tomtom.com/en/discussion/1118783/url-schemes-for-go-navigation-ios/
+    /// Universal app link accessible with `tomtomgo://x-callback-url/navigate?destination=52.371183,4.892504`
+    case tomTomGo
+
+    /// http://carobapps.com/products/inroute/url-scheme/
+    case inRoute
+
+    var isAvailable: Bool {
+        UIApplication.shared.canOpenURL(URL(string: self.urlScheme)!)
+    }
+
+    var urlScheme: String {
+        switch self {
+        case .appleMaps:
+            return "maps://"
+
+        case .googleMaps:
+            return "comgooglemaps-x-callback://?x-success=wunderlinq://&x-source=WunderLINQ"
+
+        case .scenic:
+            return ScenicAPI.Constants.deeplinkURL
+
+        case .sygic:
+            return "com.sygic.aura://"
+
+        case .waze:
+            return "waze://"
+
+        case .hereWeGo:
+            return "here-route://"
+
+        case .mapsMe:
+            return "mapsme://?backurl=wunderlinq://"
+
+        case .osmAnd:
+            return "osmandmaps://"
+
+        case .tomTomGo:
+            return "tomtomgo://"
+
+        case .inRoute:
+            return "inroute://"
         }
     }
-    
+
+    func open(_ app: UIApplication = .shared) {
+        let url = URL(string: urlScheme)!
+
+        guard isAvailable else {
+            Self.appleMaps.open()
+            return
+        }
+
+        app.open(url)
+    }
+}
+
+class NavAppHelper {
+
+    private let app: UIApplication
+
+    init(_ app: UIApplication = .shared) {
+        self.app = app
+    }
+
+    private func openAppleMaps() {
+        NavigationAppPreference.appleMaps.open()
+    }
+
+    func open() {
+        let navAppValue = UserDefaults.standard.integer(forKey: "nav_app_preference")
+        guard let navApp = NavigationAppPreference(rawValue: navAppValue) else {
+            openAppleMaps()
+            return
+        }
+        navApp.open()
+    }
+
+}
+
+extension NavAppHelper {
     class func navigateTo(destLatitude: Double, destLongitude: Double, destLabel: String?, currentLatitude: Double, currentLongitude: Double) {
-        let navApp = UserDefaults.standard.integer(forKey: "nav_app_preference")
-        switch (navApp){
-        case 0:
-            //Apple Maps
+        let navAppValue = UserDefaults.standard.integer(forKey: "nav_app_preference")
+        guard let navApp = NavigationAppPreference(rawValue: navAppValue) else { return }
+
+        switch navApp {
+        case .appleMaps:
             let coordinates = CLLocationCoordinate2DMake(destLatitude, destLongitude)
             let navPlacemark = MKPlacemark(coordinate: coordinates, addressDictionary: nil)
             let mapitem = MKMapItem(placemark: navPlacemark)
             let options = [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
             mapitem.openInMaps(launchOptions: options)
-        case 1:
-            //Google Maps
-            //googlemaps://
-            if let googleMapsURL = URL(string: "comgooglemaps-x-callback://?daddr=\(destLatitude),\(destLongitude)&directionsmode=driving&x-success=wunderlinq://?resume=true&x-source=WunderLINQ") {
+
+        case .googleMaps:
+            if let googleMapsURL = URL(string: "\(navApp.urlScheme)?daddr=\(destLatitude),\(destLongitude)&directionsmode=driving&x-success=wunderlinq://?resume=true&x-source=WunderLINQ") {
                 if (UIApplication.shared.canOpenURL(googleMapsURL)) {
                     if #available(iOS 10, *) {
                         UIApplication.shared.open(googleMapsURL, options: [:], completionHandler: nil)
@@ -166,15 +151,12 @@ class NavAppHelper {
                     }
                 }
             }
-        case 2:
-            //Scenic
-            //https://github.com/guidove/Scenic-Integration/blob/master/README.md
+        case .scenic:
             let scenic = ScenicAPI()
             scenic.sendToScenicForNavigation(coordinate: CLLocationCoordinate2D(latitude: destLatitude,longitude: destLongitude), name: destLabel ?? "WunderLINQ")
-        case 3:
-            //Sygic
-            //https://www.sygic.com/developers/professional-navigation-sdk/ios/custom-url
-            let urlString = "com.sygic.aura://coordinate|\(destLongitude)|\(destLatitude)|drive"
+
+        case .sygic:
+            let urlString = "\(navApp.urlScheme)coordinate|\(destLongitude)|\(destLatitude)|drive"
             
             if let sygicURL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                 if (UIApplication.shared.canOpenURL(sygicURL)) {
@@ -185,10 +167,9 @@ class NavAppHelper {
                     }
                 }
             }
-        case 4:
-            //Waze
-            //waze://?ll=[lat],[lon]&z=10
-            if let wazeURL = URL(string: "waze://?ll=\(destLatitude),\(destLongitude)&navigate=yes") {
+
+        case .waze:
+            if let wazeURL = URL(string: "\(navApp.urlScheme)?ll=\(destLatitude),\(destLongitude)&navigate=yes") {
                 if (UIApplication.shared.canOpenURL(wazeURL)) {
                     if #available(iOS 10, *) {
                         UIApplication.shared.open(wazeURL, options: [:], completionHandler: nil)
@@ -197,10 +178,9 @@ class NavAppHelper {
                     }
                 }
             }
-        case 5:
-            //Maps.me
-            //https://github.com/mapsme/api-ios
-            let urlString = "mapsme://route?sll=\(currentLatitude),\(currentLongitude)&saddr=\(NSLocalizedString("trip_view_waypoint_start_label", comment: ""))&dll=\(destLatitude),\(destLongitude)&daddr=\(destLabel ?? ""))&type=vehicle&backurl=wunderlinq://"
+
+        case .mapsMe:
+            let urlString = "\(navApp.urlScheme)route?sll=\(currentLatitude),\(currentLongitude)&saddr=\(NSLocalizedString("trip_view_waypoint_start_label", comment: ""))&dll=\(destLatitude),\(destLongitude)&daddr=\(destLabel ?? ""))&type=vehicle&backurl=wunderlinq://"
             if let mapsMeURL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                 if (UIApplication.shared.canOpenURL(mapsMeURL)) {
                     if #available(iOS 10, *) {
@@ -210,10 +190,9 @@ class NavAppHelper {
                     }
                 }
             }
-        case 6:
-            //OsmAnd
-            // osmandmaps://?lat=45.6313&lon=34.9955&z=8&title=New+York
-            let urlString = "osmandmaps://navigate?lat=\(destLatitude)&lon=\(destLongitude)&z=8&title=\(destLabel ?? "")"
+
+        case .osmAnd:
+            let urlString = "\(navApp.urlScheme)navigate?lat=\(destLatitude)&lon=\(destLongitude)&z=8&title=\(destLabel ?? "")"
             if let mapsMeURL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                 if (UIApplication.shared.canOpenURL(mapsMeURL)) {
                     if #available(iOS 10, *) {
@@ -223,11 +202,9 @@ class NavAppHelper {
                     }
                 }
             }
-        case 7:
-            // Here We Go
-            // https://developer.here.com/documentation/mobility-on-demand-toolkit/dev_guide/topics/navigation.html
-            // here-route://mylocation/37.870090,-122.268150,Downtown%20Berkeley?ref=WunderLINQ&m=d
-            let urlString = "here-route://mylocation/\(destLatitude),\(destLongitude),\(destLabel ?? "")?ref=WunderLINQ&m=d"
+
+        case .hereWeGo:
+            let urlString = "\(navApp.urlScheme)mylocation/\(destLatitude),\(destLongitude),\(destLabel ?? "")?ref=WunderLINQ&m=d"
             if let hereURL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                 if (UIApplication.shared.canOpenURL(hereURL)) {
                     if #available(iOS 10, *) {
@@ -237,11 +214,12 @@ class NavAppHelper {
                     }
                 }
             }
-        case 8:
+
+        case .tomTomGo:
             // TomTom GO
             // https://discussions.tomtom.com/en/discussion/1118783/url-schemes-for-go-navigation-ios/
             // tomtomgo://x-callback-url/navigate?destination=52.371183,4.892504
-            let urlString = "tomtomgo://x-callback-url/navigate?destination=\(destLatitude),\(destLongitude)"
+            let urlString = "\(navApp.urlScheme)x-callback-url/navigate?destination=\(destLatitude),\(destLongitude)"
             if let uRL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                 if (UIApplication.shared.canOpenURL(uRL)) {
                     if #available(iOS 10, *) {
@@ -251,10 +229,11 @@ class NavAppHelper {
                     }
                 }
             }
-        case 9:
+
+        case .inRoute:
             //inRoute
             //http://carobapps.com/products/inroute/url-scheme/
-            let urlString = "inroute://coordinates?action=opt&loc=Start/\(currentLatitude)/\(currentLongitude)&loc=\(destLabel ?? "")/\(destLatitude)/\(destLongitude)"
+            let urlString = "\(navApp.urlScheme)coordinates?action=opt&loc=Start/\(currentLatitude)/\(currentLongitude)&loc=\(destLabel ?? "")/\(destLatitude)/\(destLongitude)"
             if let uRL = URL(string: urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
                 if (UIApplication.shared.canOpenURL(uRL)) {
                     if #available(iOS 10, *) {
@@ -264,13 +243,6 @@ class NavAppHelper {
                     }
                 }
             }
-        default:
-            //Apple Maps
-            let coordinates = CLLocationCoordinate2DMake(destLatitude, destLongitude)
-            let navPlacemark = MKPlacemark(coordinate: coordinates, addressDictionary: nil)
-            let mapitem = MKMapItem(placemark: navPlacemark)
-            let options = [MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving]
-            mapitem.openInMaps(launchOptions: options)
         }
     }
     
@@ -406,7 +378,7 @@ class NavAppHelper {
             }
         default:
             //Apple Maps
-            let regionDistance:CLLocationDistance = 10000
+            let regionDistance: CLLocationDistance = 10000
             let coordinates = CLLocationCoordinate2DMake(destLatitude, destLongitude)
             let regionSpan = MKCoordinateRegion.init(center: coordinates, latitudinalMeters: regionDistance, longitudinalMeters: regionDistance)
             let options = [

--- a/WunderLINQ/ScenicAPI.swift
+++ b/WunderLINQ/ScenicAPI.swift
@@ -11,7 +11,10 @@ import UIKit
 import CoreLocation
 
 class ScenicAPI {
-    
+
+    enum Constants {
+        static let deeplinkURL = "https://scenicapp.space/api/openScenic.php"
+    }
     
     //  All functions attempt to open the Scenic App on the users' device.
     //  If Scenic is not on the device the App Store App will open on the Scenic Download Page.
@@ -124,7 +127,7 @@ class ScenicAPI {
      ****  vehicleType (Optional): VehicleType.carMotorcycle, .bicycle, .pedestrian (Defaults to .carMotorcycle)
      **************************************************************/
     
-    func sendToScenicForNavigation(coordinates: Array<CLLocationCoordinate2D>, name: String = "", routeMode: RouteMode = RouteMode.fast, vehicleType: VehicleType = VehicleType.carMotorcycle) {
+    func sendToScenicForNavigation(coordinates: [CLLocationCoordinate2D], name: String = "", routeMode: RouteMode = RouteMode.fast, vehicleType: VehicleType = VehicleType.carMotorcycle) {
         let polyline: String = encodeCoordinates(coordinates)
         self.sendPolyline(polyline, name: name, routeMode: routeMode, vehicleType: vehicleType)
     }
@@ -141,6 +144,15 @@ class ScenicAPI {
     func sendToScenicForNavigation(coordinate: CLLocationCoordinate2D, name: String = "") {
         let stringOfCoordinate = "\(coordinate.latitude.toNonScientificString()),\(coordinate.longitude.toNonScientificString())"
         self.sendCoordinate(stringOfCoordinate, name: name)
+    }
+
+    func generateCoordinateURL(_ coordinate: String, name: String) -> URL? {
+        var urlComponents = URLComponents(string: Constants.deeplinkURL)!
+        urlComponents.queryItems = [
+            URLQueryItem(name: "navigatelocation", value: coordinate),
+            URLQueryItem(name: "name", value: name)
+        ]
+        return urlComponents.url
     }
     
     
@@ -175,15 +187,10 @@ class ScenicAPI {
         ]
         UIApplication.shared.open(urlComponents.url!, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
     }
-    
+
     fileprivate func sendCoordinate(_ coordinate: String, name: String) {
-        var urlComponents = URLComponents(string: "https://scenicapp.space/api/openScenic.php")!
-        urlComponents.queryItems = [
-            URLQueryItem(name: "navigatelocation", value: coordinate),
-            URLQueryItem(name: "name", value: name)
-            
-        ]
-        UIApplication.shared.open(urlComponents.url!, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
+        let url = generateCoordinateURL(coordinate, name: name)
+        UIApplication.shared.open(url!, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
     }
     
     

--- a/WunderLINQ/TasksCollectionViewController.swift
+++ b/WunderLINQ/TasksCollectionViewController.swift
@@ -178,7 +178,7 @@ class TasksCollectionViewController: UICollectionViewController, UICollectionVie
         switch taskID {
         case 0:
             //Navigation
-            NavAppHelper.open()
+            NavAppHelper().open()
             break
         case 1:
             //Go Home


### PR DESCRIPTION
Hi! Hope you're well.

This PR uses a swift Enum to decode the user preference for a selected GPS app.
It simplifies the way WunderLINQ-iOS handles the opening of them as well.

Let me know what you think. 

I'm updating these kind of things to improve readability and use some fresh syntax. :)

Edit:

I noticed issue #10 , and this change made it quite trivial. 
The deeplinking via universal link to MapOut can be found by submitting a feedback request through their app. The debug informations contain something like `mapout://longitude=-0.0&latitude=0.0&zoom=8.6681337356567383&rotation=0`